### PR TITLE
Use explicit CSS path for @picocss/pico import

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,4 @@
-import "@picocss/pico";
+import "@picocss/pico/css/pico.css";
 import classNames from "classnames/bind";
 import {
   isRouteErrorResponse,

--- a/app/types.d.ts
+++ b/app/types.d.ts
@@ -1,1 +1,0 @@
-declare module "@picocss/pico";

--- a/tasks/remove-samples.ts
+++ b/tasks/remove-samples.ts
@@ -22,7 +22,7 @@ const FILES_TO_UPDATE = [
 const PICO_CSS_UPDATES = [
   {
     path: "app/root.tsx",
-    search: /^import "@picocss\/pico";\n/m,
+    search: /^import "@picocss\/pico\/css\/pico\.css";\n/m,
     replace: "",
   },
   {


### PR DESCRIPTION
Switch the side-effect import in app/root.tsx to the explicit
`css/pico.min.css` path so it is covered by vite/client's `*.css`
module declarations. This removes the need for app/types.d.ts, which
was added as a workaround for TS 6's stricter TS2882 check on
side-effect imports without type declarations.

Update tasks/remove-samples.ts to match the new import string.